### PR TITLE
Move player appropriately while colliding with a moving platform

### DIFF
--- a/CastleBoy/entity.cpp
+++ b/CastleBoy/entity.cpp
@@ -296,16 +296,20 @@ Entity* Entities::add(uint8_t type, int16_t x, int8_t y)
   return NULL;
 }
 
-signed char getMovingPlatformDirection(Entity& entity)
+char getMovingPlatformDirection(Entity& entity)
 {
-  if (entity.type == ENTITY_MOVING_PLATFORM_RIGHT)
+  if (ab.everyXFrames(3))
   {
-    return entity.state & FLAG_MISC1 ? -1 : 1;
+    if (entity.type == ENTITY_MOVING_PLATFORM_RIGHT)
+    {
+      return entity.state & FLAG_MISC1 ? -1 : 1;
+    }
+    else // entity.type == ENTITY_MOVING_PLATFORM_LEFT
+    {
+      return entity.state & FLAG_MISC1 ? 1 : -1;
+    }
   }
-  else // entity.type == ENTITY_MOVING_PLATFORM_LEFT
-  {
-    return entity.state & FLAG_MISC1 ? 1 : -1;
-  }
+  return 0;
 }
 
 void updateMovingPlatform(Entity& entity)
@@ -968,7 +972,7 @@ bool Entities::moveCollide(int16_t x, int8_t y, int8_t offsetX, int8_t offsetY, 
             // moving platform collide only if player is going down on it
             // and player is right on platform
             collide = true;
-            if (ab.everyXFrames(3))
+            if (!Map::collide(x, y, hitbox))
             {
               Player::pos.x += getMovingPlatformDirection(entity);
             }

--- a/CastleBoy/entity.cpp
+++ b/CastleBoy/entity.cpp
@@ -296,18 +296,23 @@ Entity* Entities::add(uint8_t type, int16_t x, int8_t y)
   return NULL;
 }
 
+signed char getMovingPlatformDirection(Entity& entity)
+{
+  if (entity.type == ENTITY_MOVING_PLATFORM_RIGHT)
+  {
+    return entity.state & FLAG_MISC1 ? -1 : 1;
+  }
+  else // entity.type == ENTITY_MOVING_PLATFORM_LEFT
+  {
+    return entity.state & FLAG_MISC1 ? 1 : -1;
+  }
+}
+
 void updateMovingPlatform(Entity& entity)
 {
   if (ab.everyXFrames(3))
   {
-    if (entity.type == ENTITY_MOVING_PLATFORM_RIGHT)
-    {
-      entity.pos.x += entity.state & FLAG_MISC1 ? -1 : 1;
-    }
-    else // entity.type == ENTITY_MOVING_PLATFORM_LEFT
-    {
-      entity.pos.x += entity.state & FLAG_MISC1 ? 1 : -1;
-    }
+    entity.pos.x += getMovingPlatformDirection(entity);
 
     if (++entity.counter == 23)
     {
@@ -963,6 +968,10 @@ bool Entities::moveCollide(int16_t x, int8_t y, int8_t offsetX, int8_t offsetY, 
             // moving platform collide only if player is going down on it
             // and player is right on platform
             collide = true;
+            if (ab.everyXFrames(3))
+            {
+              Player::pos.x += getMovingPlatformDirection(entity);
+            }
           }
         }
       }

--- a/CastleBoy/map.cpp
+++ b/CastleBoy/map.cpp
@@ -91,7 +91,7 @@ void Map::init(const uint8_t* source)
   // player starting position
   uint8_t playerY = temp & 0x0F;
   uint8_t playerX = pgm_read_byte(++source);
-  Player::init(playerX * TILE_WIDTH + HALF_TILE_WIDTH, playerY * TILE_HEIGHT + TILE_HEIGHT);
+  Player::init((playerX * TILE_WIDTH + HALF_TILE_WIDTH) + 1, playerY * TILE_HEIGHT + TILE_HEIGHT);
 
   // tile map position
   tilemap = ++source;
@@ -115,13 +115,12 @@ void Map::init(const uint8_t* source)
   }
 }
 
-// FIXME can we use uint8_t instead of int16_t ?
-bool Map::collide(int16_t x, int8_t y, const Box& hitbox)
+bool Map::collide(uint16_t x, int8_t y, const Box& hitbox)
 {
   x -= hitbox.x;
   y -= hitbox.y;
 
-  if (x < 0 /*|| x + hitbox.width > width * TILE_WIDTH*/)
+  if (x <= 0 /*|| x + hitbox.width > width * TILE_WIDTH*/)
   {
     // cannot get out on the sides, collide
     // WARNING can get out of right side, if we use this for projectile

--- a/CastleBoy/map.h
+++ b/CastleBoy/map.h
@@ -11,7 +11,7 @@ extern bool showBackground;
 extern Entity* boss;
 
 void init(const uint8_t* source);
-bool collide(int16_t x, int8_t y, const Box& hitbox);
+bool collide(uint16_t x, int8_t y, const Box& hitbox);
 void draw();
 }
 


### PR DESCRIPTION
I've not written C++ in a second, so tell me if I'm way off base with this.

This moves the player appropriately while standing on a moving platform, Tested to work as expected. Not thrilled about updating `Player `position from within `Entities`, but not a huge need to write a function just to do this since the `Entity` is really the "context"